### PR TITLE
Typo fixed Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ console.log(`Current Address: ${address}`);
 
 Set the network environment for transactions, ensuring users connect to the appropriate Stellar network (Mainnet or Testnet).
 this can be done by passing a boolean into the testnet parameter to any call. This is optional, and method calls will be treated
-as mainnet if this parameter is omited. If the testnet parameter is not relevant to a method call it is simply ignored
+as mainnet if this parameter is omitted. If the testnet parameter is not relevant to a method call it is simply ignored
 
 ```javascript
 const balance = await ethereum.request({


### PR DESCRIPTION
**Description:**

There is a small typo in the "Specify a Network" section under the explanation for the `testnet` parameter. The word "**omited**" is incorrectly used. The correct word should be "**omitted**."

Here is the problematic part:

> "this can be done by passing a boolean into the testnet parameter to any call. This is optional, and method calls will be treated as mainnet if this parameter is omited."

The word "**omited**" has been corrected to "**omitted**" in the updated version:

> "This can be done by passing a boolean into the `testnet` parameter to any call. This is optional, and method calls will be treated as mainnet if this parameter is **omitted**."

**Importance:**

This fix is important as it addresses a minor spelling error that could cause confusion, especially for non-native English speakers who rely on precise language in technical documentation. Ensuring correct spelling in documentation helps maintain professionalism and readability, contributing to a better user experience for developers referencing the guide.
